### PR TITLE
Remove `redirect_param` option name.

### DIFF
--- a/includes/Options.php
+++ b/includes/Options.php
@@ -19,7 +19,6 @@ final class Options {
 	 */
 	protected static $options = array(
 		'redirect'                      => 'redirect',
-		'redirect_param'                => 'redirect_param',
 		'activate'                      => 'activate',
 		'activate_param'                => 'activate_param',
 		'new_coming_soon'               => 'nfd_coming_soon',


### PR DESCRIPTION
This will no longer be necessary once https://github.com/newfold-labs/wp-module-onboarding/pull/373 is merged.