### PR TITLE
Surface errors in generate_site_meta if they happen

### DIFF
--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -117,7 +117,7 @@ class SiteGenService {
 			// Handle the error case by returning a WP_Error.
 			return new \WP_Error(
 				'nfd_onboarding_error',
-				__( 'Error generating site meta: ', 'wp-module-onboarding' ) . $identifier,
+				__( 'Error generating site meta: ', 'wp-module-onboarding' ) . $identifier . ' ' . $response['error'],
 				array( 'status' => 400 )
 			);
 		}


### PR DESCRIPTION
We're seeing issues with `message: "Error generating site meta: siteclassification"`. This doesn't fix it, but at least surfaces a more descriptive error.