### PR TITLE
Sitegen: Add helper function for resetting error state

### DIFF
--- a/includes/Services/FlowService.php
+++ b/includes/Services/FlowService.php
@@ -91,6 +91,9 @@ class FlowService {
 			$result = self::get_default_data();
 			self::update_data_in_wp_option( $result );
 		}
+
+		$result = SiteGenService::reset_error_status( $result );
+
 		return $result;
 	}
 

--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -1157,4 +1157,12 @@ class SiteGenService {
 		$data['sitegen']['homepages']['data'] = $updated_data;
 		FlowService::update_data_in_wp_option( $data );
 	}
+
+	public static function reset_error_status( $data ) {
+		if ( isset( $data['sitegen']['siteGenErrorStatus'] ) && true === $data['sitegen']['siteGenErrorStatus'] ) {
+			$data['sitegen']['siteGenErrorStatus'] = false;
+		}
+
+		return $data;
+	}
 }

--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -1158,6 +1158,12 @@ class SiteGenService {
 		FlowService::update_data_in_wp_option( $data );
 	}
 
+	/**
+	 * Reset the error status in the flow data.
+	 *
+	 * @param array $data The flow data.
+	 * @return array
+	 */
 	public static function reset_error_status( $data ) {
 		if ( isset( $data['sitegen']['siteGenErrorStatus'] ) && true === $data['sitegen']['siteGenErrorStatus'] ) {
 			$data['sitegen']['siteGenErrorStatus'] = false;


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This adds a helper function to reset the error state during onboarding on a page refresh.
