### PR TITLE
Revert "Remove dependency on some modules"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,15 @@
         }
     },
     "require": {
-        "mustache/mustache": "^2.14",
         "newfold-labs/wp-module-installer": "^1.1",
         "newfold-labs/wp-module-patterns": "^1.0",
         "newfold-labs/wp-module-ai": "^1.1",
+        "wp-forge/wp-upgrade-handler": "^1.0",
+        "mustache/mustache": "^2.14",
         "newfold-labs/wp-module-data": "^2.0",
-        "wp-forge/wp-upgrade-handler": "^1.0"
+        "newfold-labs/wp-module-coming-soon": "^1.2",
+        "newfold-labs/wp-module-performance": "^1.4",
+        "newfold-labs/wp-module-install-checker": "^1.0"
     },
     "require-dev": {
         "newfold-labs/wp-php-standards": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36ca2377c15238566ae747e1716ab8e8",
+    "content-hash": "62d714f3f8e26cb1990e9e9464467717",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -236,6 +236,114 @@
             "time": "2024-04-08T16:04:32+00:00"
         },
         {
+            "name": "newfold-labs/wp-module-coming-soon",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-coming-soon.git",
+                "reference": "335bfe833ebdc072de55ed54cd6eebe0a210e43f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-coming-soon/zipball/335bfe833ebdc072de55ed54cd6eebe0a210e43f",
+                "reference": "335bfe833ebdc072de55ed54cd6eebe0a210e43f",
+                "shasum": ""
+            },
+            "require": {
+                "newfold-labs/wp-module-data": ">=2.4.18",
+                "wp-forge/wp-upgrade-handler": "^1.0"
+            },
+            "require-dev": {
+                "newfold-labs/wp-php-standards": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\ComingSoon\\": "includes"
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "scripts": {
+                "fix": [
+                    "vendor/bin/phpcbf . --standard=phpcs.xml"
+                ],
+                "lint": [
+                    "vendor/bin/phpcs . --standard=phpcs.xml -s"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mullins",
+                    "homepage": "https://evanmullins.com"
+                }
+            ],
+            "description": "Coming Soon module for WordPress sites.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-coming-soon/tree/1.2.3",
+                "issues": "https://github.com/newfold-labs/wp-module-coming-soon/issues"
+            },
+            "time": "2024-02-29T19:54:02+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-context",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-context.git",
+                "reference": "0d852f83f353f1631309e5ae7da9cb1e046bc984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-context/zipball/0d852f83f353f1631309e5ae7da9cb1e046bc984",
+                "reference": "0d852f83f353f1631309e5ae7da9cb1e046bc984",
+                "shasum": ""
+            },
+            "require": {
+                "wp-forge/helpers": "^2.0"
+            },
+            "require-dev": {
+                "newfold-labs/wp-php-standards": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Context\\": "includes"
+                },
+                "files": [
+                    "includes/functions.php",
+                    "bootstrap.php"
+                ]
+            },
+            "scripts": {
+                "fix": [
+                    "vendor/bin/phpcbf . --standard=phpcs.xml"
+                ],
+                "lint": [
+                    "vendor/bin/phpcs . --standard=phpcs.xml -s"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mullins",
+                    "homepage": "https://evanmullins.com"
+                }
+            ],
+            "description": "Newfold module to determine context for various brands and platforms.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-context/tree/1.0.0",
+                "issues": "https://github.com/newfold-labs/wp-module-context/issues"
+            },
+            "time": "2024-02-22T18:22:13+00:00"
+        },
+        {
             "name": "newfold-labs/wp-module-data",
             "version": "2.4.24",
             "source": {
@@ -291,6 +399,45 @@
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
             "time": "2024-04-18T19:17:37+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-install-checker",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-install-checker.git",
+                "reference": "9d43e916b8c4e752b45c868b41340b84bcb686a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-install-checker/zipball/9d43e916b8c4e752b45c868b41340b84bcb686a6",
+                "reference": "9d43e916b8c4e752b45c868b41340b84bcb686a6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\InstallChecker\\": "includes/"
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "homepage": "https://wpscholar.com"
+                }
+            ],
+            "description": "A module that handles checking a WordPress installation to see if it is a fresh install and to fetch the estimated installation date.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-install-checker/tree/1.0.3",
+                "issues": "https://github.com/newfold-labs/wp-module-install-checker/issues"
+            },
+            "time": "2024-01-31T18:12:34+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",
@@ -431,6 +578,52 @@
             "time": "2024-05-01T20:37:14+00:00"
         },
         {
+            "name": "newfold-labs/wp-module-performance",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-performance.git",
+                "reference": "5e4c87d404788c61ea55e3c62e29e5df48c36340"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-performance/zipball/5e4c87d404788c61ea55e3c62e29e5df48c36340",
+                "reference": "5e4c87d404788c61ea55e3c62e29e5df48c36340",
+                "shasum": ""
+            },
+            "require": {
+                "newfold-labs/wp-module-context": "^1.0",
+                "wp-forge/collection": "^1.0",
+                "wp-forge/wp-htaccess-manager": "^1.0",
+                "wpscholar/url": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\Performance\\": "includes"
+                },
+                "files": [
+                    "includes/functions.php",
+                    "bootstrap.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@wpscholar.com"
+                }
+            ],
+            "description": "A module for managing caching functionality.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-performance/tree/1.4.1",
+                "issues": "https://github.com/newfold-labs/wp-module-performance/issues"
+            },
+            "time": "2024-04-22T22:30:42+00:00"
+        },
+        {
             "name": "wp-forge/collection",
             "version": "1.0.2",
             "source": {
@@ -547,6 +740,46 @@
                 "source": "https://github.com/wp-forge/helpers/tree/2.0"
             },
             "time": "2022-01-06T13:10:47+00:00"
+        },
+        {
+            "name": "wp-forge/wp-htaccess-manager",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-forge/wp-htaccess-manager.git",
+                "reference": "f1fac7af85c0d75a211a5d0e73cd43a7d62debe8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-forge/wp-htaccess-manager/zipball/f1fac7af85c0d75a211a5d0e73cd43a7d62debe8",
+                "reference": "f1fac7af85c0d75a211a5d0e73cd43a7d62debe8",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "includes/functions.php"
+                ],
+                "psr-4": {
+                    "WP_Forge\\WP_Htaccess_Manager\\": "includes"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@wpscholar.com"
+                }
+            ],
+            "description": "A helper library for making changes to .htaccess files in WordPress.",
+            "support": {
+                "issues": "https://github.com/wp-forge/wp-htaccess-manager/issues",
+                "source": "https://github.com/wp-forge/wp-htaccess-manager/tree/1.0"
+            },
+            "time": "2022-04-01T16:21:01+00:00"
         },
         {
             "name": "wp-forge/wp-options",


### PR DESCRIPTION
Reverts newfold-labs/wp-module-onboarding-data#84

This was incorrect since we are using the container values from these modules. We need to tag a release today and were not comfortable with these changes. Can you please clarify/check again?

@circlecube @wpscholar 