### PR TITLE
SiteGen Flow: Populate customised Typography while generating the child theme

### DIFF
--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -259,14 +259,14 @@ class SiteGenService {
 	 */
 	public static function populate_fonts_in_theme_styles( $theme_styles, $homepage_styles ) {
 
-		if (!empty($homepage_styles['blocks']) && isset($homepage_styles['blocks'][0])) {
+		if ( ! empty( $homepage_styles['blocks'] ) && isset( $homepage_styles['blocks'][0] ) ) {
 			$first_block = $homepage_styles['blocks'][0];
-	
-			if (isset($first_block['core/heading']) && isset($first_block['core/heading']['typography']['fontFamily'])) {
+
+			if ( isset( $first_block['core/heading'] ) && isset( $first_block['core/heading']['typography']['fontFamily'] ) ) {
 				$theme_styles['blocks']['core/heading']['typography']['fontFamily'] = $first_block['core/heading']['typography']['fontFamily'];
 			}
-	
-			if (isset($first_block['core/body']) && isset($first_block['core/body']['typography']['fontFamily'])) {
+
+			if ( isset( $first_block['core/body'] ) && isset( $first_block['core/body']['typography']['fontFamily'] ) ) {
 				$theme_styles['typography']['fontFamily'] = $first_block['core/body']['typography']['fontFamily'];
 			}
 		}
@@ -316,7 +316,7 @@ class SiteGenService {
 		$theme_json_data = json_decode( $theme_json, true );
 
 		$theme_json_data['settings']['color']['palette'] = $data['color']['palette'];
-		$theme_json_data['styles'] = self::populate_fonts_in_theme_styles( $theme_json_data['styles'], $data['styles'] );
+		$theme_json_data['styles']                       = self::populate_fonts_in_theme_styles( $theme_json_data['styles'], $data['styles'] );
 
 		if ( ! $theme_json_data ) {
 			return new \WP_Error(

--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -251,6 +251,30 @@ class SiteGenService {
 	}
 
 	/**
+	 * Populates the the fonts in the Theme's styles.
+	 *
+	 * @param object $theme_styles Theme styles json data.
+	 * @param object $homepage_styles Customized Homepage styles.
+	 * @return object $theme_styles Updated theme styles.
+	 */
+	public static function populate_fonts_in_theme_styles( $theme_styles, $homepage_styles ) {
+
+		if (!empty($homepage_styles['blocks']) && isset($homepage_styles['blocks'][0])) {
+			$first_block = $homepage_styles['blocks'][0];
+	
+			if (isset($first_block['core/heading']) && isset($first_block['core/heading']['typography']['fontFamily'])) {
+				$theme_styles['blocks']['core/heading']['typography']['fontFamily'] = $first_block['core/heading']['typography']['fontFamily'];
+			}
+	
+			if (isset($first_block['core/body']) && isset($first_block['core/body']['typography']['fontFamily'])) {
+				$theme_styles['typography']['fontFamily'] = $first_block['core/body']['typography']['fontFamily'];
+			}
+		}
+
+		return $theme_styles;
+	}
+
+	/**
 	 * Generates a child theme for the sitegen flow.
 	 *
 	 * @param array $data Data on each homepage and it's corresponding styles.
@@ -292,6 +316,7 @@ class SiteGenService {
 		$theme_json_data = json_decode( $theme_json, true );
 
 		$theme_json_data['settings']['color']['palette'] = $data['color']['palette'];
+		$theme_json_data['styles'] = self::populate_fonts_in_theme_styles( $theme_json_data['styles'], $data['styles'] );
 
 		if ( ! $theme_json_data ) {
 			return new \WP_Error(


### PR DESCRIPTION
## Proposed changes

In the SiteGen Flow, currently we are not saving the typography options selected by user in the Editor step. This PR ensures to save the customised Typography while generating the child theme.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
