### PR TITLE
Add customer satisfaction feedback survey

### DIFF
--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -12,6 +12,7 @@ use NewfoldLabs\WP\Module\Onboarding\Data\Themes\Fonts;
 use NewfoldLabs\WP\Module\Patterns\SiteClassification as PatternsSiteClassification;
 use NewfoldLabs\WP\Module\Data\SiteClassification\PrimaryType;
 use NewfoldLabs\WP\Module\Data\SiteClassification\SecondaryType;
+use NewfoldLabs\WP\Module\Onboarding\Data\Events;
 
 use function NewfoldLabs\WP\ModuleLoader\container;
 
@@ -246,6 +247,16 @@ class SiteGenService {
 
 		self::trash_sample_page();
 		container()->get( 'cachePurger' )->purgeAll();
+
+		container()->get( 'survey' )->create_toast_survey(
+			Events::get_category()[0],
+			'customer_satisfaction_survey',
+			array(
+				'label_key' => 'value',
+			),
+			__( 'Help us improve', 'wp-module-onboarding-data' ),
+			__( 'How satisfied were you with the ease of creating your website?', 'wp-module-onboarding-data' ),
+		);
 
 		return true;
 	}


### PR DESCRIPTION
## Proposed changes
This adds a customer satisfaction survey to the WordPress admin dashboard once a user has completed the AI Sitegen flow.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This also utilizes the [new survey module](https://github.com/newfold-labs/wp-module-survey) designed to create surveys and report survey responses to Hiive via the data module.
