### PR TITLE
Add a populate capabilities flag for brand data

### DIFF
--- a/includes/Brands.php
+++ b/includes/Brands.php
@@ -27,21 +27,26 @@ final class Brands {
 			),
 		);
 
-		return array_replace( self::get_brands( false )['bluehost'], $default_brand_data );
+		return array_replace( self::get_brands()['bluehost'], $default_brand_data );
 	}
 
 	/**
 	 * Retrieve brand-specific data for various brands such as Bluehost, Bluehost India, Web.com, etc.
 	 *
-	 * @param bool $populate_capabilities Optional. Determines whether capabilities such as `has_ai_sitegen`
-	 *                                    and `can_migrate_site` should be populated for each brand. Defaults to true.
-	 *
 	 * @return array Associative array containing configuration details for each brand, including links,
-	 *               contact information, and enabled features. Capabilities are set based on the
-	 *               $populate_capabilities argument.
+	 *               contact information, and enabled features.
 	 */
-	public static function get_brands( $populate_capabilities = true ) {
-		// Checks if customer has acess to AI Sitegen.
+	public static function get_brands(): array {
+
+		// Only populate capabilities when in the WordPress admin
+		$populate_capabilities = is_admin();
+
+		// Forcibly prevent capabilities from being fetched in front-end requests
+//		if(! is_admin()) {
+//			$populate_capabilities = false;
+//		}
+
+		// Checks if customer has access to AI Sitegen.
 		$has_ai_sitegen   = $populate_capabilities ? Config::has_ai_sitegen() : false;
 		$can_migrate_site = $populate_capabilities ? Config::can_migrate_site() : false;
 

--- a/includes/Brands.php
+++ b/includes/Brands.php
@@ -99,9 +99,7 @@ final class Brands {
 					),
 				),
 				'migrationInfo'               => array(
-					'defaultLink' => Config::is_jarvis() ?
-					'https://www.bluehost.com/my-account/hosting/details/sites/add/transfer'
-					: 'https://my.bluehost.com/cgi/services/migration',
+					'defaultLink' => 'https://www.bluehost.com/my-account/hosting/details/sites/add/transfer',
 				),
 				'config'                      => array(
 					'enabled_flows'  => array(
@@ -401,15 +399,9 @@ final class Brands {
 				'twitterUrl'                  => 'https://twitter.com/hostgator',
 				'youtubeUrl'                  => 'https://www.youtube.com/user/hostgator',
 				'linkedinUrl'                 => 'https://www.linkedin.com/company/hostgator-com/',
-				'accountUrl'                  => Config::is_jarvis() ?
-				'https://www.hostgator.com/my-account/login'
-				: 'https://portal.hostgator.com/',
-				'domainsUrl'                  => Config::is_jarvis() ?
-				'https://www.hostgator.com/my-account/domain-center/domain-list'
-				: 'https://portal.hostgator.com/domain/manage',
-				'emailUrl'                    => Config::is_jarvis() ?
-				'https://www.hostgator.com/my-account/hosting/details/email'
-				: 'https://portal.hostgator.com/email',
+				'accountUrl'                  => 'https://www.hostgator.com/my-account/login',
+				'domainsUrl'                  => 'https://www.hostgator.com/my-account/domain-center/domain-list',
+				'emailUrl'                    => 'https://www.hostgator.com/my-account/hosting/details/email',
 				'pluginDashboardPage'         => \admin_url( 'admin.php?page=hostgator' ),
 				'phoneNumbers'                => array(
 					'support' => '866-964-2867',

--- a/includes/Brands.php
+++ b/includes/Brands.php
@@ -37,18 +37,9 @@ final class Brands {
 	 *               contact information, and enabled features.
 	 */
 	public static function get_brands(): array {
-
-		// Only populate capabilities when in the WordPress admin
-		$populate_capabilities = is_admin();
-
-		// Forcibly prevent capabilities from being fetched in front-end requests
-//		if(! is_admin()) {
-//			$populate_capabilities = false;
-//		}
-
 		// Checks if customer has access to AI Sitegen.
-		$has_ai_sitegen   = $populate_capabilities ? Config::has_ai_sitegen() : false;
-		$can_migrate_site = $populate_capabilities ? Config::can_migrate_site() : false;
+		$has_ai_sitegen   = Config::has_ai_sitegen();
+		$can_migrate_site = Config::can_migrate_site();
 
 		return array(
 			'bluehost'       => array(

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -41,15 +41,6 @@ final class Config {
 	}
 
 	/**
-	 * Checks if the site is on Jarvis hosting.
-	 *
-	 * @return boolean
-	 */
-	public static function is_jarvis() {
-		return self::get_site_capability( 'isJarvis' );
-	}
-
-	/**
 	 * Gets the current customer capability if he has access to AI Sitegen.
 	 *
 	 * @return boolean

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -36,8 +36,8 @@ final class Config {
 	 * @return boolean
 	 */
 	public static function get_site_capability( $capability ) {
-		// Make sure we don't fetch capabilities on the front-end
-		if ( ! is_admin() ) {
+		// Only fetch capabilities in the admin when a user is logged in
+		if ( ! is_admin() || ! is_user_logged_in() ) {
 			return false;
 		}
 		$site_capabilities = new SiteCapabilities();

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -36,6 +36,10 @@ final class Config {
 	 * @return boolean
 	 */
 	public static function get_site_capability( $capability ) {
+		// Make sure we don't fetch capabilities on the front-end
+		if ( ! is_admin() ) {
+			return false;
+		}
 		$site_capabilities = new SiteCapabilities();
 		return $site_capabilities->get( $capability );
 	}

--- a/includes/Data.php
+++ b/includes/Data.php
@@ -37,14 +37,11 @@ final class Data {
 	/**
 	 * Establish the brand to apply to the Onboarding experience.
 	 *
-	 * @param bool $populate_capabilities Optional. Determines whether capabilities should be populated
-	 *                                    for the selected brand. Defaults to true.
-	 *
 	 * @return array The configuration array of the current brand. If the specified brand is not found,
 	 *               returns the default brand configuration.
 	 */
-	public static function current_brand( $populate_capabilities = true ) {
-		$brands = Brands::get_brands( $populate_capabilities );
+	public static function current_brand() {
+		$brands = Brands::get_brands();
 
 		return array_key_exists( NFD_ONBOARDING_PLUGIN_BRAND, $brands ) ?
 			$brands[ NFD_ONBOARDING_PLUGIN_BRAND ] :

--- a/includes/Flows/Flows.php
+++ b/includes/Flows/Flows.php
@@ -220,16 +220,13 @@ final class Flows {
 	/**
 	 * Retrieve all the known onboarding flows.
 	 *
-	 * @param bool $populate_capabilities Optional. Determines whether capabilities should be populated
-	 *                                    for the current brand. Defaults to true.
-	 *
 	 * @return array Associative array of onboarding flows. A value of true for each key indicates that the
 	 *               flow has been approved. A value of null indicates the flow has not been approved or has
 	 *               been temporarily disabled. If no enabled flows are found, default flows are provided with
 	 *               a value of false.
 	 */
-	public static function get_flows( $populate_capabilities = true ) {
-		$current_brand = Data::current_brand( $populate_capabilities );
+	public static function get_flows() {
+		$current_brand = Data::current_brand();
 		return isset( $current_brand['config']['enabled_flows'] )
 		? $current_brand['config']['enabled_flows'] : array(
 			'wp-setup'  => false,


### PR DESCRIPTION
## Proposed changes

This PR adds a `$populate_capabilities` flag to the brand data configuration to ensure it is populated only when needed.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
