### PR TITLE
Remove runtime fallback pages; default type to other when classification fails

### DIFF
--- a/includes/Data.php
+++ b/includes/Data.php
@@ -5,7 +5,6 @@ use NewfoldLabs\WP\Module\CustomerBluehost\CustomerBluehost;
 use NewfoldLabs\WP\Module\Onboarding\Data\Flows\Flows;
 use NewfoldLabs\WP\Module\Installer\Services\PluginInstaller;
 use NewfoldLabs\WP\Module\Onboarding\Data\Services\SiteGenService;
-use NewfoldLabs\WP\Module\Onboarding\Data\Services\WonderBlocksService;
 
 use function NewfoldLabs\WP\ModuleLoader\container;
 
@@ -34,7 +33,6 @@ final class Data {
 			'currentUserDetails'  => self::wp_current_user_details(),
 			'isFreshInstallation' => self::is_fresh_installation(),
 			'sentryInitDsnURL'    => 'https://cd5bd4c30b914e0d1d0f49413e600afa@o4506197201715200.ingest.us.sentry.io/4507383861805056',
-			'fallbackHomepages'   => WonderBlocksService::get_fallback_homepages(),
 		);
 	}
 

--- a/includes/Services/WonderBlocksService.php
+++ b/includes/Services/WonderBlocksService.php
@@ -299,6 +299,7 @@ class WonderBlocksService {
 
 		// Cache the result in WordPress transients for 1 hour (3600 seconds)
 		// This ensures consistency across all requests during the onboarding session
+		$fallback_homepages['fallback'] = true;
 		set_transient( 'nfd_fallback_homepages_cache', $fallback_homepages, 3600 );
 
 		return $fallback_homepages;

--- a/includes/Services/WonderBlocksService.php
+++ b/includes/Services/WonderBlocksService.php
@@ -128,24 +128,22 @@ class WonderBlocksService {
 	 */
 	public static function get_template_from_slug( $template_slug ) {
 		$primary_type = PrimaryType::instantiate_from_option();
-		if ( ! $primary_type ) {
-			return false;
-		}
+		$primary_type = $primary_type ? $primary_type->value : 'other';
+
 		$secondary_type = SecondaryType::instantiate_from_option();
-		if ( ! $secondary_type ) {
-			return false;
-		}
+		$secondary_type = $secondary_type ? $secondary_type->value : 'other';
 
 		$wonder_blocks_slug = self::strip_prefix_from_slug( $template_slug );
 		$request            = new WonderBlocksFetchRequest(
 			array(
 				'endpoint'       => 'templates',
 				'slug'           => $wonder_blocks_slug,
-				'primary_type'   => $primary_type->value,
-				'secondary_type' => $secondary_type->value,
+				'primary_type'   => $primary_type,
+				'secondary_type' => $secondary_type,
 			)
 		);
-		$template           = WonderBlocks::fetch( $request );
+
+		$template = WonderBlocks::fetch( $request );
 
 		if ( ! empty( $template ) ) {
 			$template['categories'] = array( $template['categories'], 'yith-wonder-pages' );
@@ -171,21 +169,18 @@ class WonderBlocksService {
 	 */
 	public static function get_pattern_from_slug( $pattern_slug ) {
 		$primary_type = PrimaryType::instantiate_from_option();
-		if ( ! $primary_type ) {
-			return false;
-		}
+		$primary_type = $primary_type ? $primary_type->value : 'other';
+
 		$secondary_type = SecondaryType::instantiate_from_option();
-		if ( ! $secondary_type ) {
-			return false;
-		}
+		$secondary_type = $secondary_type ? $secondary_type->value : 'other';
 
 		$wonder_blocks_slug = self::strip_prefix_from_slug( $pattern_slug );
 		$request            = new WonderBlocksFetchRequest(
 			array(
 				'endpoint'       => 'patterns',
 				'slug'           => $wonder_blocks_slug,
-				'primary_type'   => $primary_type->value,
-				'secondary_type' => $secondary_type->value,
+				'primary_type'   => $primary_type,
+				'secondary_type' => $secondary_type,
 			)
 		);
 		$patterns           = WonderBlocks::fetch( $request );
@@ -246,8 +241,8 @@ class WonderBlocksService {
 	public static function get_fallback_homepages() {
 
 		$cached_homepages = get_transient( 'nfd_fallback_homepages_cache' );
-		
-		if ( $cached_homepages !== false ) {
+
+		if ( false !== $cached_homepages ) {
 			return $cached_homepages;
 		}
 
@@ -255,35 +250,35 @@ class WonderBlocksService {
 
 		$homepage_configs = array(
 			'homepage-2' => array(
-				'header'   => 'wonder-blocks/header-14',
-				'template' => 'wonder-blocks/home-2',
-				'footer'   => 'wonder-blocks/footer-12',
-				'title'    => 'Bold & Dynamic',
-				'slug'     => 'homepage-2',
+				'header'      => 'wonder-blocks/header-14',
+				'template'    => 'wonder-blocks/home-2',
+				'footer'      => 'wonder-blocks/footer-12',
+				'title'       => 'Bold & Dynamic',
+				'slug'        => 'homepage-2',
 				'description' => 'A bold and dynamic design that makes a strong impression.',
 			),
 			'homepage-3' => array(
-				'header'   => 'wonder-blocks/header-15',
-				'template' => 'wonder-blocks/home-3',
-				'footer'   => 'wonder-blocks/footer-14',
-				'title'    => 'Contemporary Style',
-				'slug'     => 'homepage-3',
+				'header'      => 'wonder-blocks/header-15',
+				'template'    => 'wonder-blocks/home-3',
+				'footer'      => 'wonder-blocks/footer-14',
+				'title'       => 'Contemporary Style',
+				'slug'        => 'homepage-3',
 				'description' => 'A contemporary design with modern aesthetics and clean lines.',
 			),
 			'homepage-4' => array(
-				'header'   => 'wonder-blocks/header-16',
-				'template' => 'wonder-blocks/home-4',
-				'footer'   => 'wonder-blocks/footer-6',
-				'title'    => 'Minimalist Elegance',
-				'slug'     => 'homepage-4',
+				'header'      => 'wonder-blocks/header-16',
+				'template'    => 'wonder-blocks/home-4',
+				'footer'      => 'wonder-blocks/footer-6',
+				'title'       => 'Minimalist Elegance',
+				'slug'        => 'homepage-4',
 				'description' => 'A minimalist design that focuses on simplicity and elegance.',
 			),
 			'homepage-5' => array(
-				'header'   => 'wonder-blocks/header-17',
-				'template' => 'wonder-blocks/home-5',
-				'footer'   => 'wonder-blocks/footer-11',
-				'title'    => 'Warm & Welcoming',
-				'slug'     => 'homepage-5',
+				'header'      => 'wonder-blocks/header-17',
+				'template'    => 'wonder-blocks/home-5',
+				'footer'      => 'wonder-blocks/footer-11',
+				'title'       => 'Warm & Welcoming',
+				'slug'        => 'homepage-5',
 				'description' => 'A warm and welcoming design that creates a friendly atmosphere.',
 			),
 		);


### PR DESCRIPTION
## Proposed changes

Story: https://jira.newfold.com/browse/PRESS0-2896

1. When fallback is added during runtime, we don’t have the primary and secondary types. This causes `get_fallback_homepages` to populate the array with empty values, since the wonder blocks pattern and template fetching functions return `false`. That’s what was causing the blank fallback screen.
2. We now request fallback pages only when homepage generation fails on the second attempt in the frontend See: https://github.com/newfold-labs/wp-module-onboarding/pull/807. This ensures we have the primary and secondary types available if the site meta has been set. This ensures that we are showing relevant fallbacks based on the classification instead of just returning a random fallback.
3. If the site classification meta still hasn't been set and we still don’t have a primary or secondary type, we default to "primary:other", "secondary:other", which generates random fallback homepages under the “other” category instead of showing a blank screen.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->