### PR TITLE
Skip ai-flow when option nfd_origin_prompt is in the database

### DIFF
--- a/includes/Data.php
+++ b/includes/Data.php
@@ -33,7 +33,18 @@ final class Data {
 			'currentUserDetails'  => self::wp_current_user_details(),
 			'isFreshInstallation' => self::is_fresh_installation(),
 			'sentryInitDsnURL'    => 'https://cd5bd4c30b914e0d1d0f49413e600afa@o4506197201715200.ingest.us.sentry.io/4507383861805056',
+			'hasOriginPrompt'     => self::has_origin_prompt(),
 		);
+	}
+
+	/**
+	 * Whether an origin prompt exists (pre-filled user prompt for alternate onboarding flow).
+	 *
+	 * @return bool True if the nfd_origin_prompt option exists and is non-empty.
+	 */
+	public static function has_origin_prompt() {
+		$prompt = \get_option( 'nfd_origin_prompt', '' );
+		return ! empty( $prompt ) && is_string( $prompt );
 	}
 
 	/**

--- a/includes/Services/SiteGenService.php
+++ b/includes/Services/SiteGenService.php
@@ -119,8 +119,17 @@ class SiteGenService {
 		}
 
 		// If the site info is a string, convert it to an array.
-		if ( gettype( $site_info ) === 'string' ) {
+		if ( is_string( $site_info ) ) {
 			$site_info = array( 'site_description' => $site_info );
+		}
+
+		// Reject invalid site_info (e.g. false when prompt not yet in Redux) to avoid fatal in AI module.
+		if ( empty( $site_info ) || ! is_array( $site_info ) || ! isset( $site_info['site_description'] ) ) {
+			return new \WP_Error(
+				'nfd_onboarding_error',
+				__( 'Invalid or missing site description for site meta generation.', 'wp-module-onboarding-data' ),
+				array( 'status' => 400 )
+			);
 		}
 
 		$identifier = self::get_identifier_name( $identifier );


### PR DESCRIPTION
## Proposed changes

If option named `nfd_origin_prompt` is in database:
- Skip prompt screen
- Skip logo screen
- Skip preview screen
- Generate 1 site
- Drop user into WP editor with editor chat as we do today at end of onboarding

This is an alternate flow and does not impact our normal flow if a prompt doesn’t exist in database.

## Type of Change

`wp-content/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-onboarding-data/includes/Data.php`
has_origin_prompt(), runtime['hasOriginPrompt']

`wp-content/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-onboarding-data/includes/Services/SiteGenService.php`
A guard was added in instantiate_site_meta() so that if $site_info is false, not an array, or missing site_description, the method returns a WP_Error instead of calling the AI module and causing a fatal. 

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [x] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

https://www.loom.com/share/2cffeb3c9c754391a2e0075069d5ff52

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

To test it, add a wp_option named `nfd_origin_prompt` with content similar to "the website of an Italian pizza restaurant in Baltimora." and visit the `wp-admin/index.php?page=nfd-onboarding` page.
Be sure to reset your onboarding by visiting `/wp-admin/index.php?page=nfd-onboarding&nfd_reset_onboarding=1` first.

Module `wp-module-onboading` should stay at same branch.