### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent guidance – wp-module-onboarding-data
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-onboarding-data** – A non-toggleable module providing a standardized interface for onboarding data. Used by wp-module-onboarding and other modules. Depends on wp-module-installer, wp-module-patterns, wp-module-ai, wp-module-data, wp-module-performance, wp-module-install-checker, wp-module-survey, mustache, wp-forge/wp-upgrade-handler. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. See docs/dependencies.md.
+
+- **Architecture:** Registers with the loader; provides data API for onboarding. See docs/integration.md.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Includes | `includes/` |
+| Tests | `tests/` |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,4 @@ composer run test
 
 ## Keeping documentation current
 
-When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.
+When you change code, features, or workflows, update the docs. Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present). When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,22 @@
+# Dependencies
+
+## Runtime
+
+| Package | Purpose |
+|---------|---------|
+| **newfold-labs/wp-module-installer** | Installer integration. |
+| **newfold-labs/wp-module-patterns** | Content patterns. |
+| **newfold-labs/wp-module-ai** | AI integration. |
+| **wp-forge/wp-upgrade-handler** | Versioned upgrades. |
+| **mustache/mustache** | Templating. |
+| **newfold-labs/wp-module-data** | Data/context. |
+| **newfold-labs/wp-module-performance** | Performance module. |
+| **newfold-labs/wp-module-install-checker** | Install checks. |
+| **newfold-labs/wp-module-survey** | Survey integration. |
+
+## Dev
+
+- **newfold-labs/wp-php-standards** – PHPCS.
+- **johnpbloch/wordpress** – WordPress core for tests.
+- **lucatume/wp-browser** – Codeception wpunit.
+- **wp-cli/i18n-command** – i18n.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 ## Runtime

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,15 @@
+# Development
+
+## Linting
+
+- **PHP:** `composer run lint`, `composer run fix`. Uses repo phpcs config.
+
+## Testing
+
+- **Codeception wpunit:** `composer run test`, `composer run test-coverage`.
+
+## Workflow
+
+1. Make changes in `includes/`.
+2. Run `composer run lint` and `composer run test` before committing.
+3. When changing dependencies, update [dependencies.md](dependencies.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Linting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,30 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.3+.
+- **Composer.** The module has multiple Newfold and third-party runtime dependencies; see docs/dependencies.md.
+
+## Install
+
+```bash
+composer install
+```
+
+## Run tests
+
+```bash
+composer run test
+composer run test-coverage
+```
+
+## Lint
+
+```bash
+composer run lint
+composer run fix
+```
+
+## Using in a host plugin
+
+This module is typically pulled in as a dependency of wp-module-onboarding or other modules. See [integration.md](integration.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# wp-module-onboarding-data – Documentation index
+
+Documentation for wp-module-onboarding-data, for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does and who maintains it. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and tests. |
+| [integration.md](integration.md) | How the module registers and how other modules use it. |
+| [development.md](development.md) | Lint, test, and workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Consuming this module:** [integration.md](integration.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-onboarding-data – Documentation index
 
 Documentation for wp-module-onboarding-data, for **humans** and **AI agents**. Start here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,9 @@
+# Integration
+
+## How the module registers
+
+The module is non-toggleable and registers with the Newfold Module Loader. It provides the onboarding data interface used by wp-module-onboarding and other modules (e.g. next-steps, ecommerce). Other code accesses onboarding state and site info through this module’s API.
+
+## Dependencies
+
+See [dependencies.md](dependencies.md).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the module registers

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,9 @@
+# Overview
+
+## What the module does
+
+**wp-module-onboarding-data** provides a standardized interface for interacting with onboarding data. It is non-toggleable (always loaded when present) and is consumed by wp-module-onboarding and other modules that need onboarding state, site info, and related data. It depends on several other Newfold modules (installer, patterns, ai, data, performance, install-checker, survey) and mustache/upgrade-handler.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-onboarding-data
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)