### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write      # Required for called reusable workflow to commit translation updates.
       pull-requests: write # Required for called reusable workflow to create or update pull requests.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-onboarding-data'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for called reusable workflow to commit translation updates.
+      pull-requests: write # Required for called reusable workflow to create or update pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-onboarding-data'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -46,6 +47,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required for called reusable workflow to clone this private repository.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -32,7 +32,8 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     permissions:
-      contents: read
+      contents: read # Required for called reusable workflow to clone this private repository.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -44,7 +45,7 @@ jobs:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
     permissions:
-      contents: read
+      contents: read # Required for called reusable workflow to clone this private repository.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 30
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to publish coverage artifacts and gh-pages.
       pull-requests: write # Required for reusable workflow to update pull request checks or comments.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for reusable workflow to publish coverage artifacts and gh-pages.
+      pull-requests: write # Required for reusable workflow to update pull request checks or comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,12 +8,15 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
+    permissions:
+      contents: write      # Required for called reusable workflow to push translation updates.
+      pull-requests: write # Required for called reusable workflow to open or update pull requests.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write      # Required for called reusable workflow to push translation updates.
       pull-requests: write # Required for called reusable workflow to open or update pull requests.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -11,6 +11,7 @@ jobs:
   call-crowdin-upload-workflow:
     permissions:
       contents: read # Required for called reusable workflow to read repository sources for upload.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,8 +3,14 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
+    permissions:
+      contents: read # Required for called reusable workflow to read repository sources for upload.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -13,10 +13,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 7 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint-check-php.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed) |
| Permissions commit | `3b81eb82` |
| Timeouts commit | `1cc9a948` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` *(only the standard two-line comment was added ahead of existing `permissions: {}`)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` *(replaced prior workflow-wide `contents: read` with `{}` plus comments)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` *(replaced workflow-wide `contents: read` with `{}` plus comments)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` *(replaced workflow-wide write scopes with `{}` plus comments)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` *(added `{}` plus comments)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-check-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| codecoverage-main.yml | 1 job was missing an explicit scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [3] |
| i18n-crowdin-download.yml | caller job lacked an explicit job block before remediation | call-crowdin-workflow | `contents: write`, `pull-requests: write` [2] |
| lint-check-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| satis-update.yml | 1 job was missing explicit `permissions: {}` | webhook | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 1 job tightened from broad read to none | setup | `permissions: {}` *(was incorrectly inheriting/using `contents: read` despite no checkout or GitHub API use)* [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: workflow: BEFORE top-level `contents: read` -> AFTER top-level `permissions: {}` (with required comments) -- keeps default denial at workflow level per least privilege; cloning/API access delegated to callee jobs -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- no checkout and no GitHub API usage beyond echoing refs -- [3] |
| 3 | `brand-plugin-test-playwright.yml` :: `bluehost` / `bluehost-dev`: BEFORE `contents: read` (no rationale) -> AFTER same scopes with `# Required for called reusable workflow to clone...` trailing comments -- aligns with documentation-style least-privilege rationale only -- [3] |
| 4 | `codecoverage-main.yml` :: workflow: BEFORE `contents: read` -> AFTER `permissions: {}` -- prior scope was broader than necessary for the split-job layout -- [3] |
| 5 | `codecoverage-main.yml` :: `codecoverage`: BEFORE un-commented tokens -> AFTER annotated `contents: write` / `pull-requests: write` -- matches assumed needs of `reusable-codecoverage.yml` (push/deploy surfaces and PR feedback) **without independent verification of that reusable workflow's full API footprint** -- [2] |
| 6 | `auto-translate.yml` :: `translate`: BEFORE uncommented scopes -> AFTER same scopes with inline rationale for the reusable translations workflow -- [2] |
| 7 | `i18n-crowdin-download.yml` :: workflow: BEFORE combined write scopes -> AFTER top-level `{}` plus job-local write scopes matching Crowdin-download reusable behavior -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| auto-translate.yml | translate | `30` | Bounded wait for reusable translation orchestration plus external translator API dependence. |
| brand-plugin-test-playwright.yml | setup | `30` | Short runner job; avoids hanging echo/output steps masking upstream issues. |
| brand-plugin-test-playwright.yml | bluehost | `30` | Playwright plus brand-plugin reusable pipeline can be long-running; aligns with sibling job cap. |
| brand-plugin-test-playwright.yml | bluehost-dev | `30` | Same rationale as parallel Playwright callee against `develop`. |
| codecoverage-main.yml | get-repo-name | `30` | Trivial extraction but inherits global safety standard. |
| codecoverage-main.yml | codecoverage | `30` | Multi-version PHPUnit/Codeception merges can exceed naive defaults. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | Crowdin + PR churn may stall on networks or retries. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | Upload jobs can block on Crowdin ingestion. |
| lint-check-php.yml | phpcs | `30` | Composer installs and PHPCS on large trees warrant a ceiling despite usually finishing faster. |
| satis-update.yml | webhook | `30` | Outbound dispatch should resolve quickly; cap prevents orphaned runs. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | **Strict placement rule:** `.workflow_audit_instructions.md` asks for top-level `permissions: {}` *immediately* before `jobs:`. In `brand-plugin-test-playwright.yml`, `concurrency:` sits between that block and `jobs:` — consider moving `concurrency` above `permissions` if you must satisfy the wording literally (GitHub YAML still accepts current order). |
| 2 | **Third-party / reusable workflows:** Confidence for `pull-requests: write` and `contents: write` remains [2] on anything delegating to `newfold-labs/workflows@main` (`reusable-codecoverage`, translations, Crowdin, Playwright helpers) until those files are audited for undocumented API calls (`issues`, `actions`, GitHub Pages, etc.). |
| 3 | **`lint-check-php.yml` helpers:** Third-party actions (`technote-space/get-diff-action`, `actions/cache`) were not re-fetched byte-for-byte; they are assumed satisfied by `contents: read` typical for shallow checkout caches—flag for review if CI ever authenticates separately. |
| 4 | **`satis-update.yml`:** `peter-evans/repository-dispatch` uses PAT `secrets.WEBHOOK_TOKEN`, so `GITHUB_TOKEN` stays unused; `{}` aligns with PAT-offloaded permissions model [3]. |
| 5 | [REDACTED] |


