### PR TITLE
Skip AI code review on Dependabot PRs

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -21,7 +21,13 @@ permissions: {}
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    # Skip Dependabot PRs: GitHub withholds repo secrets from Dependabot-context
+    # runs, so the AI gateway secrets are empty and the review would hard-fail.
+    # A skipped job counts as passing, so it never blocks Dependabot auto-merge.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'
     name: Review PR diff
     uses: newfold-labs/workflows/.github/workflows/reusable-code-review.yml@main
     with:


### PR DESCRIPTION
## Why

Follow-up to scheduled Dependabot auto-merge.

The `Review PR diff` AI code-review check hard-fails on **every** Dependabot PR with `Missing required secret: CLOUDFLARE_ACCOUNT_ID`. GitHub withholds repository secrets from Dependabot-context runs, so the Cloudflare AI gateway secrets are empty and the reusable review workflow errors out.

Because the auto-merge gate requires **all** checks to be green, that permanently red check blocks auto-merge for all Dependabot PRs.

## What

Guard the AI-review job on `github.actor != 'dependabot[bot]'` so it is **skipped** on Dependabot PRs. A skipped job counts as passing, so it no longer blocks auto-merge, and we don't spend AI-gateway quota reviewing dependency bumps.

No change to behavior on human/fork PRs.