### PR TITLE
Update workflows for main-networksolutions 

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -3,7 +3,7 @@ name: Check for Updates to Translations
 on:
   push:
     branches:
-      - 'main'
+      - 'main-networksolutions'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for the branch that have not completed.

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     types: [ opened, reopened, ready_for_review, synchronize ]
     branches:
-      - main
+      - main-networksolutions
+      - trunk
   workflow_dispatch:
 
 permissions:
@@ -28,8 +29,8 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
 
-  bluehost:
-    name: Bluehost Build and Test Playwright
+  netsol:
+    name: Netsol Build and Test Playwright
     needs: setup
     permissions:
       contents: read
@@ -37,11 +38,11 @@ jobs:
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
-      plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+      plugin-repo: 'newfold-labs/wp-plugin-web'
     secrets: inherit
 
-  bluehost-dev:
-    name: Bluehost Dev Build and Test Playwright
+  netsol-dev:
+    name: Netsol Dev Build and Test Playwright
     needs: setup
     permissions:
       contents: read
@@ -49,7 +50,7 @@ jobs:
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
-      plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+      plugin-repo: 'newfold-labs/wp-plugin-web'
       plugin-branch: 'develop'
-      artifact-name: 'wp-plugin-bluehost-develop'
+      artifact-name: 'wp-plugin-web-develop'
     secrets: inherit

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -1,16 +1,29 @@
 name: Codecoverage-Main
 
+# DISABLED for main-networksolutions (3.x NS line).
+# Code coverage continues to run on the `main` branch (4.x).
+#
+# Technical reasons automatic coverage is not enabled here:
+# 1. reusable-codecoverage.yml (newfold-labs/workflows) hardcodes `github.ref == 'refs/heads/main'`
+#    for gh-pages commits, README badge updates, and the PR baseline coverage percentage — so pushes
+#    to main-networksolutions would run tests but would not publish or compare coverage correctly.
+# 2. gh-pages is shared across the whole repo (e.g. gh-pages/phpunit/); enabling coverage on both
+#    main and main-networksolutions would produce conflicting reports and badge values.
+#
+# To re-enable for NS: coordinate an upstream fix in newfold-labs/workflows (e.g. a production-branch
+# input or separate gh-pages path), then uncomment the push/pull_request triggers below.
+
 # Runs PHPUnit unit and Codeception wp-browser wpunit tests, merges the code coverage, commits the html report to
 # GitHub Pages, generates a README badge with the coverage percentage.
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [ opened, reopened, ready_for_review, synchronize ]
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main-networksolutions
+  # pull_request:
+  #   types: [ opened, reopened, ready_for_review, synchronize ]
+  #   branches:
+  #     - main-networksolutions
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -6,7 +6,7 @@ on:
       base_branch:
         description: 'Base branch for the pull request'
         required: false
-        default: 'main'
+        default: 'main-networksolutions'
 
 permissions:
   contents: write

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -1,9 +1,13 @@
 name: 'Lint Checker: PHP'
 on:
   push:
+    branches:
+      - main-networksolutions
     paths:
       - '**.php'
   pull_request:
+    branches:
+      - main-networksolutions
     types: [opened, edited, reopened, ready_for_review]
     paths:
       - '**.php'


### PR DESCRIPTION
## Summary

Aligns GitHub Actions workflows on `main-networksolutions` with the dual-branch release model used by `newfold-labs/wp-module-onboarding` ([reference PR #1249](https://github.com/newfold-labs/wp-module-onboarding/pull/1249)). GitHub’s default branch remains `main`; this PR only changes workflow files on the NS line.

| File | Change |
|------|--------|
| `brand-plugin-test-playwright.yml` | PR target `main` → `main-networksolutions` (+ `trunk`); Bluehost jobs → Netsol jobs using `newfold-labs/wp-plugin-web` |
| `auto-translate.yml` | Push trigger `main` → `main-networksolutions`; `text_domain` unchanged (`wp-module-onboarding-data`) |
| `lint-check-php.yml` | Scoped `push` and `pull_request` to `main-networksolutions` |
| `codecoverage-main.yml` | Disabled automatic `push`/`pull_request` triggers; added header comment explaining why; `workflow_dispatch` retained |
| `i18n-crowdin-download.yml` | Default `base_branch` `main` → `main-networksolutions` |

**Unchanged (by design):** `satis-update.yml`, `i18n-crowdin-upload.yml`, `ai-code-review.yml`, `dependabot.yml` (Dependabot reads config only from default branch `main` — NS dependency updates remain manual).

**Skipped:** `lint-check-spa.yml` (no SPA in this repo), `newfold-prep-release.yml` (not present on `main`; no `bootstrap.php` version file).

## Test plan

- [ ] PRs into `main-networksolutions` trigger: PHP lint, Playwright (Netsol / `wp-plugin-web`), AI code review
- [ ] Pushes to `main-networksolutions` trigger: PHP lint, auto-translate
- [ ] PRs/pushes to `main` do **not** pick up NS-scoped workflows from this branch (workflow files on `main` still target `main`)
- [ ] Codecoverage does **not** auto-run on `main-networksolutions` push/PR
- [ ] Manual `workflow_dispatch` still works for: codecoverage, Crowdin download/upload
- [ ] `text_domain` in auto-translate remains `wp-module-onboarding-data`
- [ ] Playwright jobs use `wp-plugin-web` (not Bluehost)


Made with [Cursor](https://cursor.com)